### PR TITLE
Refactor node, add examples, go mod

### DIFF
--- a/crush.go
+++ b/crush.go
@@ -1,32 +1,121 @@
 package gocrush
 
-const maxRetries uint8 = 3
+import "fmt"
 
-// Select returns a node.
-func Select(parent Node, input int64, requestedNodesCount uint8, nodeType int) []Node {
-	var results []Node
+const (
+	defaultMaxRetries = uint8(3)
+	//Root represents default root tree.
+	Root = uint8(0)
+	//DataCenter represents default first hierarchy element
+	DataCenter = uint8(1)
+	//Rack represents default second hierarchy element
+	Rack = uint8(2)
+	//Node represents default third hierarchy element
+	Node = uint8(3)
+	//Disk represents default fourth hierarchy element
+	Disk = uint8(4)
+)
+
+// NodeTypes represents mapping of
+// various tree levels
+type NodeTypes map[string]uint8
+
+var defaultNodeTypes = NodeTypes{
+	"root":       Root,
+	"dataCenter": DataCenter,
+	"rack":       Rack,
+	"node":       Node,
+	"disk":       Disk,
+}
+
+// Client is an instance of gocrush.
+type Client struct {
+	nodeTypes  NodeTypes
+	maxRetries uint8
+}
+
+// Config holds Client configuration.
+type Config struct {
+	NodeTypes  NodeTypes
+	MaxRetries uint8
+}
+
+var conf *Config
+
+// New instantinates gocrush library.
+// It will expect zero or exactly one Config struct,
+// returns Client which holds all methods and internal config.
+func New(options ...*Config) (*Client, error) {
+	conf = &Config{
+		NodeTypes:  defaultNodeTypes,
+		MaxRetries: defaultMaxRetries,
+	}
+	c := Client{}
+	if len(options) == 1 {
+		opts := options[0]
+		if opts.NodeTypes != nil {
+			if err := c.SetNodeTypes(opts); err != nil {
+				return nil, fmt.Errorf("could not set node types: %v", err)
+			}
+		} else {
+			c.nodeTypes = conf.NodeTypes
+		}
+		if opts.MaxRetries != 0 {
+			if err := c.SetMaxRetries(opts); err != nil {
+				return nil, fmt.Errorf("could not set max retries: %v", err)
+			}
+		} else {
+			c.maxRetries = conf.MaxRetries
+		}
+	}
+	return &c, nil
+}
+
+// SetNodeTypes sets node groups.
+// This setting may change hashing so it is not adviced to be used
+// after first use of hashing.
+func (c *Client) SetNodeTypes(opts *Config) error {
+	if len(opts.NodeTypes) != 0 {
+		c.nodeTypes = opts.NodeTypes
+		return nil
+	}
+	return fmt.Errorf("wrong options provided to SetNodeTypes")
+}
+
+// SetMaxRetries sets how many times we will retry
+// to get node we are looking for before giving up
+func (c *Client) SetMaxRetries(opts *Config) error {
+	if opts.MaxRetries > 0 {
+		c.maxRetries = opts.MaxRetries
+		return nil
+	}
+	return fmt.Errorf("MaxRetries should be uint8 type")
+}
+
+// Select returns a slice of nodes which are it's childs and
+// been selected by given algorithm.
+func (c *Client) Select(parent CNode, input int64, requestedNodesCount uint8, nodeType uint8) []CNode {
+	var results []CNode
 	for replica := uint8(0); replica < requestedNodesCount; replica++ {
 		var totalFailures uint8
-		var result Node
+		var result CNode
 		for retryDescent := true; retryDescent; retryDescent = false {
 			var replicaFailures uint8
 			bucket := parent
 			for retryBucket := true; retryBucket; retryBucket = false {
-				var selector uint8
 				if replica == 0 {
-					selector = replica + totalFailures
+					result = bucket.Select(input, int64(replica+totalFailures))
 				} else {
-					selector = replica + replicaFailures
+					result = bucket.Select(input, int64(replica+replicaFailures))
 				}
-				result = bucket.Select(input, int64(selector))
 				switch {
-				case result.GetType() != nodeType:
+				case result.GetGroup() != nodeType:
 					bucket = result
 					retryBucket = true
 				case contains(results, result):
 					totalFailures++
 					replicaFailures++
-					if replicaFailures >= maxRetries {
+					if replicaFailures >= c.maxRetries {
 						retryDescent = true
 						break
 					}
@@ -43,7 +132,7 @@ func Select(parent Node, input int64, requestedNodesCount uint8, nodeType int) [
 	return results
 }
 
-func contains(nodes []Node, n Node) bool {
+func contains(nodes []CNode, n CNode) bool {
 	i := n.GetID()
 	for _, node := range nodes {
 		if node.GetID() == i {
@@ -53,7 +142,7 @@ func contains(nodes []Node, n Node) bool {
 	return false
 }
 
-func isDefunct(n Node) bool {
+func isDefunct(n CNode) bool {
 	if n.IsLeaf() {
 		if n.IsFailed() || n.IsOverloaded() {
 			return true

--- a/crush_test.go
+++ b/crush_test.go
@@ -8,21 +8,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	root       = 0
-	dataCenter = 1
-	rack       = 2
-	node       = 3
-	disk       = 4
-)
-
 func TestCrushStraw(t *testing.T) {
 	tree := makeStrawTree()
-	nodes1 := Select(tree, 15, 3, node)
+	g, err := New()
+	if err != nil {
+		panic(err)
+	}
+	nodes1 := g.Select(tree, 15, 3, Node)
 
-	nodes2 := Select(tree, 4564564564, 3, node)
+	nodes2 := g.Select(tree, 4564564564, 3, Node)
 
-	nodes3 := Select(tree, 8789342322, 3, node)
+	nodes3 := g.Select(tree, 8789342322, 3, Node)
 	for _, node := range nodes1 {
 		log.Printf("[STRAW] For key %d got node : %s", 15, node.GetID())
 	}
@@ -32,24 +28,28 @@ func TestCrushStraw(t *testing.T) {
 	for _, node := range nodes3 {
 		log.Printf("[STRAW] For key %d got node : %s", 8789342322, node.GetID())
 	}
-	assert.Equal(t, len(tree.GetChildren()), 4, "")
-	//assert.Equal(t, len(tree.GetChildren()), 5, "")
+	assert.Equal(t, len(tree.GetChildrens()), 4, "")
+	//assert.Equal(t, len(tree.GetChildrens()), 5, "")
 }
 
 func TestCrushStrawTreeChange(t *testing.T) {
 	tree := makeStrawTree()
 	var key int64 = 64646436
-	nodes := Select(tree, key, 3, node)
+	g, err := New()
+	if err != nil {
+		panic(err)
+	}
+	nodes := g.Select(tree, key, 3, Node)
 
-	subTree, _ := tree.Children[2].(*TestingNode)
-	subSubTree, _ := subTree.Children[2].(*TestingNode)
+	subTree, _ := tree.childrens[2].(*CrushNode)
+	subSubTree, _ := subTree.childrens[2].(*CrushNode)
 
-	subSubTree.Children = append(subSubTree.Children[:1], subSubTree.Children[2:]...)
-	subSubTree.Selector = NewStrawSelector(subSubTree)
-	for idx, node := range subSubTree.GetChildren() {
+	subSubTree.childrens = append(subSubTree.childrens[:1], subSubTree.childrens[2:]...)
+	subSubTree.selector = NewStrawSelector(subSubTree)
+	for idx, node := range subSubTree.GetChildrens() {
 		log.Printf("[STRAW] Node: (%d idx) %s", idx, node.GetID())
 	}
-	nodes2 := Select(tree, key, 3, node)
+	nodes2 := g.Select(tree, key, 3, Node)
 
 	for _, node := range nodes {
 		log.Printf("[STRAW] For key %d got node : %s", key, node.GetID())
@@ -58,17 +58,21 @@ func TestCrushStrawTreeChange(t *testing.T) {
 	for _, node := range nodes2 {
 		log.Printf("[STRAW] For key %d got node : %s", key, node.GetID())
 	}
-	assert.Equal(t, len(tree.GetChildren()), 4, "")
-	//assert.Equal(t, len(tree.GetChildren()), 5, "")
+	assert.Equal(t, len(tree.GetChildrens()), 4, "")
+	//assert.Equal(t, len(tree.GetChildrens()), 5, "")
 }
 
 func TestCrushTree(t *testing.T) {
 	tree := makeTreeTree()
-	nodes1 := Select(tree, 15, 3, node)
+	g, err := New()
+	if err != nil {
+		panic(err)
+	}
+	nodes1 := g.Select(tree, 15, 3, Node)
 
-	nodes2 := Select(tree, 4564564564, 3, node)
+	nodes2 := g.Select(tree, 4564564564, 3, Node)
 
-	nodes3 := Select(tree, 8789342322, 3, node)
+	nodes3 := g.Select(tree, 8789342322, 3, Node)
 	for _, node := range nodes1 {
 		log.Printf("[TREE] For key %d got node : %s", 15, node.GetID())
 	}
@@ -78,24 +82,28 @@ func TestCrushTree(t *testing.T) {
 	for _, node := range nodes3 {
 		log.Printf("[TREE] For key %d got node : %s", 8789342322, node.GetID())
 	}
-	assert.Equal(t, len(tree.GetChildren()), 4, "")
-	//assert.Equal(t, len(tree.GetChildren()), 5, "")
+	assert.Equal(t, len(tree.GetChildrens()), 4, "")
+	//assert.Equal(t, len(tree.GetChildrens()), 5, "")
 }
 
 func TestCrushTreeTreeChange(t *testing.T) {
 	tree := makeTreeTree()
 	var key int64 = 64646436
-	nodes := Select(tree, key, 3, node)
+	g, err := New()
+	if err != nil {
+		panic(err)
+	}
+	nodes := g.Select(tree, key, 3, Node)
 
-	subTree, _ := tree.Children[3].(*TestingNode)
-	subSubTree, _ := subTree.Children[0].(*TestingNode)
+	subTree, _ := tree.childrens[3].(*CrushNode)
+	subSubTree, _ := subTree.childrens[0].(*CrushNode)
 
-	subSubTree.Children = append(subSubTree.Children[:1], subSubTree.Children[2:]...)
-	subSubTree.Selector = NewTreeSelector(subSubTree)
-	for idx, node := range subSubTree.GetChildren() {
+	subSubTree.childrens = append(subSubTree.childrens[:1], subSubTree.childrens[2:]...)
+	subSubTree.selector = NewTreeSelector(subSubTree)
+	for idx, node := range subSubTree.GetChildrens() {
 		log.Printf("[TREE] Node: (%d idx) %s", idx, node.GetID())
 	}
-	nodes2 := Select(tree, key, 3, node)
+	nodes2 := g.Select(tree, key, 3, Node)
 
 	for _, node := range nodes {
 		log.Printf("[TREE] For key %d got node : %s", key, node.GetID())
@@ -104,218 +112,218 @@ func TestCrushTreeTreeChange(t *testing.T) {
 	for _, node := range nodes2 {
 		log.Printf("[TREE] For key %d got node : %s", key, node.GetID())
 	}
-	assert.Equal(t, len(tree.GetChildren()), 4, "")
-	//assert.Equal(t, len(tree.GetChildren()), 5, "")
+	assert.Equal(t, len(tree.GetChildrens()), 4, "")
+	//assert.Equal(t, len(tree.GetChildrens()), 5, "")
 }
 
-func makeStrawTree() *TestingNode {
-	var parent = new(TestingNode)
-	parent.ID = "root"
-	parent.Type = root
-	parent.Weight = 0
-	parent.Children = make([]Node, 4)
+func makeStrawTree() *CrushNode {
+	var parent = new(CrushNode)
+	parent.id = "root"
+	parent.group = Root
+	parent.weight = 0
+	parent.childrens = make([]CNode, 4)
 	for dc := 0; dc < 4; dc++ {
-		var dcNode = new(TestingNode)
-		dcNode.Parent = parent
-		dcNode.Weight = 1
-		dcNode.Type = dataCenter
-		dcNode.ID = parent.ID + ":DataCenter" + strconv.Itoa(dc)
-		dcNode.Children = make([]Node, 4)
+		var dcNode = new(CrushNode)
+		dcNode.parent = parent
+		dcNode.weight = 1
+		dcNode.group = DataCenter
+		dcNode.id = parent.id + ":DataCenter" + strconv.Itoa(dc)
+		dcNode.childrens = make([]CNode, 4)
 
-		parent.Children[dc] = dcNode
+		parent.childrens[dc] = dcNode
 
 		for rk := 0; rk < 4; rk++ {
-			var rkNode = new(TestingNode)
-			rkNode.Parent = dcNode
-			rkNode.Type = rack
-			rkNode.Weight = 1
-			rkNode.ID = dcNode.ID + ":rack" + strconv.Itoa(rk)
-			rkNode.Children = make([]Node, 4)
+			var rkNode = new(CrushNode)
+			rkNode.parent = dcNode
+			rkNode.group = Rack
+			rkNode.weight = 1
+			rkNode.id = dcNode.id + ":rack" + strconv.Itoa(rk)
+			rkNode.childrens = make([]CNode, 4)
 
-			dcNode.Children[rk] = rkNode
+			dcNode.childrens[rk] = rkNode
 			for nd := 0; nd < 4; nd++ {
-				var ndNode = new(TestingNode)
-				ndNode.Parent = rkNode
-				ndNode.Type = node
-				ndNode.Weight = 1
-				ndNode.ID = rkNode.ID + ":Node" + strconv.Itoa(nd)
-				ndNode.Children = make([]Node, 4)
+				var ndNode = new(CrushNode)
+				ndNode.parent = rkNode
+				ndNode.group = Node
+				ndNode.weight = 1
+				ndNode.id = rkNode.id + ":Node" + strconv.Itoa(nd)
+				ndNode.childrens = make([]CNode, 4)
 
-				rkNode.Children[nd] = ndNode
+				rkNode.childrens[nd] = ndNode
 				for dsk := 0; dsk < 4; dsk++ {
-					var dskNode = new(TestingNode)
-					dskNode.Parent = ndNode
-					dskNode.Type = disk
-					dskNode.Weight = 1
-					dskNode.ID = ndNode.ID + ":Disk" + strconv.Itoa(dsk)
-					dskNode.Selector = NewStrawSelector(dskNode)
-					ndNode.Children[dsk] = dskNode
+					var dskNode = new(CrushNode)
+					dskNode.parent = ndNode
+					dskNode.group = Disk
+					dskNode.weight = 1
+					dskNode.id = ndNode.id + ":Disk" + strconv.Itoa(dsk)
+					dskNode.selector = NewStrawSelector(dskNode)
+					ndNode.childrens[dsk] = dskNode
 				}
-				ndNode.Selector = NewStrawSelector(ndNode)
+				ndNode.selector = NewStrawSelector(ndNode)
 			}
-			rkNode.Selector = NewStrawSelector(rkNode)
+			rkNode.selector = NewStrawSelector(rkNode)
 		}
-		dcNode.Selector = NewStrawSelector(dcNode)
+		dcNode.selector = NewStrawSelector(dcNode)
 	}
-	parent.Selector = NewStrawSelector(parent)
+	parent.selector = NewStrawSelector(parent)
 	return parent
 }
 
-func makeSimpleStrawTree() *TestingNode {
-	var parent = new(TestingNode)
-	parent.ID = "root"
-	parent.Type = root
-	parent.Weight = 0
-	parent.Children = make([]Node, 1)
+func makeSimpleStrawTree() *CrushNode {
+	var parent = new(CrushNode)
+	parent.id = "root"
+	parent.group = Root
+	parent.weight = 0
+	parent.childrens = make([]CNode, 1)
 	for dc := 0; dc < 1; dc++ {
-		var dcNode = new(TestingNode)
-		dcNode.Parent = parent
-		dcNode.Weight = 1
-		dcNode.Type = dataCenter
-		dcNode.ID = parent.ID + ":DataCenter" + strconv.Itoa(dc)
-		dcNode.Children = make([]Node, 1)
+		var dcNode = new(CrushNode)
+		dcNode.parent = parent
+		dcNode.weight = 1
+		dcNode.group = DataCenter
+		dcNode.id = parent.id + ":DataCenter" + strconv.Itoa(dc)
+		dcNode.childrens = make([]CNode, 1)
 
-		parent.Children[dc] = dcNode
+		parent.childrens[dc] = dcNode
 
 		for rk := 0; rk < 1; rk++ {
-			var rkNode = new(TestingNode)
-			rkNode.Parent = dcNode
-			rkNode.Type = rack
-			rkNode.Weight = 1
-			rkNode.ID = dcNode.ID + ":rack" + strconv.Itoa(rk)
-			rkNode.Children = make([]Node, 3)
+			var rkNode = new(CrushNode)
+			rkNode.parent = dcNode
+			rkNode.group = Rack
+			rkNode.weight = 1
+			rkNode.id = dcNode.id + ":rack" + strconv.Itoa(rk)
+			rkNode.childrens = make([]CNode, 3)
 
-			dcNode.Children[rk] = rkNode
+			dcNode.childrens[rk] = rkNode
 			for nd := 0; nd < 3; nd++ {
-				var ndNode = new(TestingNode)
-				ndNode.Parent = rkNode
-				ndNode.Type = node
-				ndNode.Weight = 1
-				ndNode.ID = rkNode.ID + ":Node" + strconv.Itoa(nd)
-				ndNode.Children = make([]Node, 1)
+				var ndNode = new(CrushNode)
+				ndNode.parent = rkNode
+				ndNode.group = Node
+				ndNode.weight = 1
+				ndNode.id = rkNode.id + ":Node" + strconv.Itoa(nd)
+				ndNode.childrens = make([]CNode, 1)
 
-				rkNode.Children[nd] = ndNode
+				rkNode.childrens[nd] = ndNode
 				for dsk := 0; dsk < 1; dsk++ {
-					var dskNode = new(TestingNode)
-					dskNode.Parent = ndNode
-					dskNode.Type = disk
-					dskNode.Weight = 1
-					dskNode.ID = ndNode.ID + ":Disk" + strconv.Itoa(dsk)
-					dskNode.Selector = NewStrawSelector(dskNode)
-					ndNode.Children[dsk] = dskNode
+					var dskNode = new(CrushNode)
+					dskNode.parent = ndNode
+					dskNode.group = Disk
+					dskNode.weight = 1
+					dskNode.id = ndNode.id + ":Disk" + strconv.Itoa(dsk)
+					dskNode.selector = NewStrawSelector(dskNode)
+					ndNode.childrens[dsk] = dskNode
 				}
-				ndNode.Selector = NewStrawSelector(ndNode)
+				ndNode.selector = NewStrawSelector(ndNode)
 			}
-			rkNode.Selector = NewStrawSelector(rkNode)
+			rkNode.selector = NewStrawSelector(rkNode)
 		}
-		dcNode.Selector = NewStrawSelector(dcNode)
+		dcNode.selector = NewStrawSelector(dcNode)
 	}
-	parent.Selector = NewStrawSelector(parent)
+	parent.selector = NewStrawSelector(parent)
 	return parent
 }
 
-func makeTreeTree() *TestingNode {
-	var parent = new(TestingNode)
-	parent.ID = "root"
-	parent.Type = root
-	parent.Weight = 0
-	parent.Children = make([]Node, 4)
+func makeTreeTree() *CrushNode {
+	var parent = new(CrushNode)
+	parent.id = "root"
+	parent.group = Root
+	parent.weight = 0
+	parent.childrens = make([]CNode, 4)
 	for dc := 0; dc < 4; dc++ {
-		var dcNode = new(TestingNode)
-		dcNode.Parent = parent
-		dcNode.Weight = 1
-		dcNode.Type = dataCenter
-		dcNode.ID = parent.ID + ":DataCenter" + strconv.Itoa(dc)
-		dcNode.Children = make([]Node, 4)
+		var dcNode = new(CrushNode)
+		dcNode.parent = parent
+		dcNode.weight = 1
+		dcNode.group = DataCenter
+		dcNode.id = parent.id + ":DataCenter" + strconv.Itoa(dc)
+		dcNode.childrens = make([]CNode, 4)
 
-		parent.Children[dc] = dcNode
+		parent.childrens[dc] = dcNode
 
 		for rk := 0; rk < 4; rk++ {
-			var rkNode = new(TestingNode)
-			rkNode.Parent = dcNode
-			rkNode.Type = rack
-			rkNode.Weight = 1
-			rkNode.ID = dcNode.ID + ":rack" + strconv.Itoa(rk)
-			rkNode.Children = make([]Node, 4)
+			var rkNode = new(CrushNode)
+			rkNode.parent = dcNode
+			rkNode.group = Rack
+			rkNode.weight = 1
+			rkNode.id = dcNode.id + ":rack" + strconv.Itoa(rk)
+			rkNode.childrens = make([]CNode, 4)
 
-			dcNode.Children[rk] = rkNode
+			dcNode.childrens[rk] = rkNode
 			for nd := 0; nd < 4; nd++ {
-				var ndNode = new(TestingNode)
-				ndNode.Parent = rkNode
-				ndNode.Type = node
-				ndNode.Weight = 1
-				ndNode.ID = rkNode.ID + ":Node" + strconv.Itoa(nd)
-				ndNode.Children = make([]Node, 4)
+				var ndNode = new(CrushNode)
+				ndNode.parent = rkNode
+				ndNode.group = Node
+				ndNode.weight = 1
+				ndNode.id = rkNode.id + ":Node" + strconv.Itoa(nd)
+				ndNode.childrens = make([]CNode, 4)
 
-				rkNode.Children[nd] = ndNode
+				rkNode.childrens[nd] = ndNode
 				for dsk := 0; dsk < 4; dsk++ {
-					var dskNode = new(TestingNode)
-					dskNode.Parent = ndNode
-					dskNode.Type = disk
-					dskNode.Weight = 1
-					dskNode.ID = ndNode.ID + ":Disk" + strconv.Itoa(dsk)
-					dskNode.Selector = NewTreeSelector(dskNode)
-					ndNode.Children[dsk] = dskNode
+					var dskNode = new(CrushNode)
+					dskNode.parent = ndNode
+					dskNode.group = Disk
+					dskNode.weight = 1
+					dskNode.id = ndNode.id + ":Disk" + strconv.Itoa(dsk)
+					dskNode.selector = NewTreeSelector(dskNode)
+					ndNode.childrens[dsk] = dskNode
 				}
-				ndNode.Selector = NewTreeSelector(ndNode)
+				ndNode.selector = NewTreeSelector(ndNode)
 			}
-			rkNode.Selector = NewTreeSelector(rkNode)
+			rkNode.selector = NewTreeSelector(rkNode)
 		}
-		dcNode.Selector = NewTreeSelector(dcNode)
+		dcNode.selector = NewTreeSelector(dcNode)
 	}
-	parent.Selector = NewTreeSelector(parent)
+	parent.selector = NewTreeSelector(parent)
 	return parent
 }
 
-func makeSimpleTreeTree() *TestingNode {
-	var parent = new(TestingNode)
-	parent.ID = "root"
-	parent.Type = root
-	parent.Weight = 0
-	parent.Children = make([]Node, 1)
+func makeSimpleTreeTree() *CrushNode {
+	var parent = new(CrushNode)
+	parent.id = "root"
+	parent.group = Root
+	parent.weight = 0
+	parent.childrens = make([]CNode, 1)
 	for dc := 0; dc < 1; dc++ {
-		var dcNode = new(TestingNode)
-		dcNode.Parent = parent
-		dcNode.Weight = 1
-		dcNode.Type = dataCenter
-		dcNode.ID = parent.ID + ":DataCenter" + strconv.Itoa(dc)
-		dcNode.Children = make([]Node, 1)
+		var dcNode = new(CrushNode)
+		dcNode.parent = parent
+		dcNode.weight = 1
+		dcNode.group = DataCenter
+		dcNode.id = parent.id + ":DataCenter" + strconv.Itoa(dc)
+		dcNode.childrens = make([]CNode, 1)
 
-		parent.Children[dc] = dcNode
+		parent.childrens[dc] = dcNode
 
 		for rk := 0; rk < 1; rk++ {
-			var rkNode = new(TestingNode)
-			rkNode.Parent = dcNode
-			rkNode.Type = rack
-			rkNode.Weight = 1
-			rkNode.ID = dcNode.ID + ":rack" + strconv.Itoa(rk)
-			rkNode.Children = make([]Node, 3)
+			var rkNode = new(CrushNode)
+			rkNode.parent = dcNode
+			rkNode.group = Rack
+			rkNode.weight = 1
+			rkNode.id = dcNode.id + ":rack" + strconv.Itoa(rk)
+			rkNode.childrens = make([]CNode, 3)
 
-			dcNode.Children[rk] = rkNode
+			dcNode.childrens[rk] = rkNode
 			for nd := 0; nd < 3; nd++ {
-				var ndNode = new(TestingNode)
-				ndNode.Parent = rkNode
-				ndNode.Type = node
-				ndNode.Weight = 1
-				ndNode.ID = rkNode.ID + ":Node" + strconv.Itoa(nd)
-				ndNode.Children = make([]Node, 1)
+				var ndNode = new(CrushNode)
+				ndNode.parent = rkNode
+				ndNode.group = Node
+				ndNode.weight = 1
+				ndNode.id = rkNode.id + ":Node" + strconv.Itoa(nd)
+				ndNode.childrens = make([]CNode, 1)
 
-				rkNode.Children[nd] = ndNode
+				rkNode.childrens[nd] = ndNode
 				for dsk := 0; dsk < 1; dsk++ {
-					var dskNode = new(TestingNode)
-					dskNode.Parent = ndNode
-					dskNode.Type = disk
-					dskNode.Weight = 1
-					dskNode.ID = ndNode.ID + ":Disk" + strconv.Itoa(dsk)
-					dskNode.Selector = NewTreeSelector(dskNode)
-					ndNode.Children[dsk] = dskNode
+					var dskNode = new(CrushNode)
+					dskNode.parent = ndNode
+					dskNode.group = Disk
+					dskNode.weight = 1
+					dskNode.id = ndNode.id + ":Disk" + strconv.Itoa(dsk)
+					dskNode.selector = NewTreeSelector(dskNode)
+					ndNode.childrens[dsk] = dskNode
 				}
-				ndNode.Selector = NewTreeSelector(ndNode)
+				ndNode.selector = NewTreeSelector(ndNode)
 			}
-			rkNode.Selector = NewTreeSelector(rkNode)
+			rkNode.selector = NewTreeSelector(rkNode)
 		}
-		dcNode.Selector = NewTreeSelector(dcNode)
+		dcNode.selector = NewTreeSelector(dcNode)
 	}
-	parent.Selector = NewTreeSelector(parent)
+	parent.selector = NewTreeSelector(parent)
 	return parent
 }

--- a/examples/first/go.mod
+++ b/examples/first/go.mod
@@ -1,0 +1,7 @@
+module github.com/gocrush/examples/first
+
+go 1.14
+
+replace github.com/gocrush => ../../
+
+require github.com/gocrush v0.0.0

--- a/examples/first/go.sum
+++ b/examples/first/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/first/main.go
+++ b/examples/first/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/gocrush"
+)
+
+func main() {
+	tree, err := makeNewStrawTree()
+	if err != nil {
+		panic(err)
+	}
+	g, err := gocrush.New(&gocrush.Config{
+		MaxRetries: 10,
+	})
+	if err != nil {
+		panic(err)
+	}
+	selectedNodes := g.Select(tree, 12312313131, 3, gocrush.Node)
+	for _, node := range selectedNodes {
+		fmt.Printf("Node ID: %v, isLeaf: %v, Type: %v, Parent: %v, IsFailed: %v\n", node.GetID(), node.IsLeaf(), node.GetGroup(), node.GetParent().GetID(), node.IsFailed())
+
+	}
+}
+
+func makeNewStrawTree() (*gocrush.CrushNode, error) {
+	parent, err := gocrush.NewNode(&gocrush.CNodeConfig{
+		ID:     "root",
+		Group:  gocrush.Root,
+		Weight: 0,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Could not initialize parent node: %v", err)
+	}
+	for dc := 0; dc < 4; dc++ {
+		dataCenter, err := gocrush.NewNode(&gocrush.CNodeConfig{
+			ID:     parent.GetID() + ":dataCenter" + strconv.Itoa(dc),
+			Group:  gocrush.DataCenter,
+			Weight: 1,
+			Parent: parent,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("Could not initialize dataCenter node %v: %v", dc, err)
+		}
+		parent.AddChildren(dataCenter)
+		for rk := 0; rk < 4; rk++ {
+			rack, err := gocrush.NewNode(&gocrush.CNodeConfig{
+				ID:     parent.GetID() + ":rack" + strconv.Itoa(rk),
+				Group:  gocrush.DataCenter,
+				Weight: 1,
+				Parent: dataCenter,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("Could not initialize rack node %v: %v", rk, err)
+			}
+			dataCenter.AddChildren(rack)
+			for nd := 0; nd < 4; nd++ {
+				node, err := gocrush.NewNode(&gocrush.CNodeConfig{
+					ID:     parent.GetID() + ":node" + strconv.Itoa(nd),
+					Group:  gocrush.DataCenter,
+					Weight: 1,
+					Parent: rack,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("Could not initialize node %v: %v", nd, err)
+				}
+				rack.AddChildren(node)
+				for dsk := 0; nd < 4; nd++ {
+					disk, err := gocrush.NewNode(&gocrush.CNodeConfig{
+						ID:     parent.GetID() + ":disk" + strconv.Itoa(dsk),
+						Group:  gocrush.DataCenter,
+						Weight: 1,
+						Parent: node,
+					})
+					if err != nil {
+						return nil, fmt.Errorf("Could not initialize disk node %v: %v", dsk, err)
+					}
+					disk.SetSelector(gocrush.NewStrawSelector(disk))
+					node.AddChildren(disk)
+				}
+				node.SetSelector(gocrush.NewStrawSelector(node))
+			}
+			rack.SetSelector(gocrush.NewStrawSelector(rack))
+		}
+		dataCenter.SetSelector(gocrush.NewStrawSelector(dataCenter))
+	}
+	parent.SetSelector(gocrush.NewStrawSelector(parent))
+	return parent, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/gocrush
+
+go 1.14
+
+require github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/hashingselector.go
+++ b/hashingselector.go
@@ -10,21 +10,21 @@ import (
 // HashingSelector holds Hashing selector.
 type HashingSelector struct {
 	tokenList tokenList
-	tokenMap  map[int64]Node
+	tokenMap  map[int64]CNode
 }
 
 // NewHashingSelector returns new instance of HashingSelector
-func NewHashingSelector(n Node) *HashingSelector {
+func NewHashingSelector(n CNode) *HashingSelector {
 	var h = new(HashingSelector)
-	var nodes = n.GetChildren()
+	var nodes = n.GetChildrens()
 	var maxWeight int64 = 0
-	h.tokenMap = make(map[int64]Node)
+	h.tokenMap = make(map[int64]CNode)
 	for _, node := range nodes {
 		if node.GetWeight() > maxWeight {
 			maxWeight = node.GetWeight()
 		}
 		var hash []byte
-		for i := int64(0); i < 500 * node.GetWeight() / maxWeight; i++ {
+		for i := int64(0); i < 500*node.GetWeight()/maxWeight; i++ {
 			var input []byte
 			if len(hash) == 0 {
 				input = []byte(node.GetID())
@@ -95,7 +95,7 @@ func btoi(b []byte) int64 {
 }
 
 // Select implements Select interface
-func (s *HashingSelector) Select(input int64, round int64) Node {
+func (s *HashingSelector) Select(input int64, round int64) CNode {
 	buf := new(bytes.Buffer)
 	binary.Write(buf, binary.LittleEndian, input)
 	binary.Write(buf, binary.LittleEndian, round)

--- a/hashingselector_test.go
+++ b/hashingselector_test.go
@@ -1,22 +1,22 @@
 package gocrush
 
 import (
-	"github.com/stretchr/testify/assert"
-	//"log"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHashingSelector(t *testing.T) {
-	node := new(TestingNode)
-	node.Children = make([]Node, 8)
+	node := new(CrushNode)
+	node.childrens = make([]CNode, 8)
 	counter := make(map[string]int)
 	for i := 0; i < 8; i++ {
-		child := new(TestingNode)
-		child.Weight = 1
-		child.ID = "Child" + strconv.Itoa(i)
-		node.Children[i] = child
-		counter[child.ID] = 0
+		child := new(CrushNode)
+		child.weight = 1
+		child.id = "Child" + strconv.Itoa(i)
+		node.childrens[i] = child
+		counter[child.id] = 0
 	}
 	selector := NewHashingSelector(node)
 
@@ -39,14 +39,14 @@ func TestHashingSelector(t *testing.T) {
 }
 
 func TestHashingSelectorAdd(t *testing.T) {
-	node := new(TestingNode)
-	node.Children = make([]Node, 8)
-	counter := make(map[string]Node)
+	node := new(CrushNode)
+	node.childrens = make([]CNode, 8)
+	counter := make(map[string]CNode)
 	for i := 0; i < 8; i++ {
-		child := new(TestingNode)
-		child.Weight = 1
-		child.ID = "Child" + strconv.Itoa(i)
-		node.Children[i] = child
+		child := new(CrushNode)
+		child.weight = 1
+		child.id = "Child" + strconv.Itoa(i)
+		node.childrens[i] = child
 	}
 	selector := NewHashingSelector(node)
 	for i := int64(0); i < 5; i++ {
@@ -56,10 +56,10 @@ func TestHashingSelectorAdd(t *testing.T) {
 		}
 
 	}
-	child := new(TestingNode)
-	child.Weight = 1
-	child.ID = "Child9"
-	node.Children = append(node.Children, child)
+	child := new(CrushNode)
+	child.weight = 1
+	child.id = "Child9"
+	node.childrens = append(node.childrens, child)
 	selector = NewHashingSelector(node)
 	for i := int64(0); i < 5; i++ {
 		for r := int64(0); r < 3; r++ {

--- a/jenkinshash.go
+++ b/jenkinshash.go
@@ -59,7 +59,6 @@ func hash4(a, b, c, d int64) int64 {
 }
 
 func hashMix(a, b, c int64) (int64, int64, int64) {
-
 	a = subtract(a, b)
 	a = subtract(a, c)
 	a = xor(a, c>>13)

--- a/node.go
+++ b/node.go
@@ -1,101 +1,247 @@
 package gocrush
 
-// Node represents CRUSH node.
-type Node interface {
-	GetChildren() []Node
-	GetType() int
+import "fmt"
+
+// CNode represents CRUSH node
+type CNode interface {
+	GetChildrens() []CNode
+	GetGroup() uint8
 	GetWeight() int64
 	GetID() string
 	IsFailed() bool
 	IsOverloaded() bool
 	GetSelector() Selector
 	SetSelector(Selector)
-	GetParent() Node
+	GetParent() CNode
 	IsLeaf() bool
-	Select(input int64, round int64) Node
+	Select(input int64, round int64) CNode
+}
+
+// Selector interface is implemented by
+// hashing algorithms.
+type Selector interface {
+	Select(input int64, round int64) CNode
 }
 
 // Overload may be used to skip given node manually.
 // If function returns TRUE, than node will be disabled.
-type Overload func(Node) bool
+type Overload func(CNode) bool
 
-// CrushNode is a mock used by unit tests
+// CrushNode represents single crush node and
+// implements CNode interface
 type CrushNode struct {
-	Selector Selector
+	id         string
+	group      uint8
+	parent     CNode
+	childrens  []CNode
+	selector   Selector
+	weight     int64
+	failed     bool
+	overloaded bool
 }
 
-// TestingNode is a mock used by unit tests
-type TestingNode struct {
-	Children []Node
-	CrushNode
-	Weight   int64
-	Parent   Node
-	Failed   bool
+// CNodeConfig defines CrushNode configuration.
+type CNodeConfig struct {
+	ID         string // required for new node
+	Group      uint8  // required for new node
+	Parent     CNode
+	Childrens  []CNode
+	Selector   Selector
+	Weight     int64
+	Failed     bool
 	Overloaded bool
-	ID       string
-	Type     int
 }
 
-// GetSelector is part of TestingNode
-func (n CrushNode) GetSelector() Selector {
-	return n.Selector
+var cNodeConf *CNodeConfig
+
+// NewNode creates node entity.
+// It will expect zero or exactly one Config struct,
+// returns CNode which holds all methods and internal config.
+func NewNode(options ...*CNodeConfig) (*CrushNode, error) {
+	cNodeConf = &CNodeConfig{}
+	c := CrushNode{}
+	if len(options) == 1 {
+		opts := options[0]
+		if err := c.SetID(opts.ID); err != nil {
+			return nil, fmt.Errorf("could not set ID for node: %v", err)
+		}
+		if err := c.SetGroup(opts.Group); err != nil {
+			return nil, fmt.Errorf("could not set group: %v", err)
+		}
+		if len(opts.Childrens) != 0 {
+			if err := c.AddChildrens(opts.Childrens); err != nil {
+				return nil, fmt.Errorf("could not add childs: %v", err)
+			}
+		}
+		if opts.Weight != 0 {
+			if err := c.SetWeight(opts.Weight); err != nil {
+				return nil, fmt.Errorf("could node set weight: %v", err)
+			}
+		}
+		if opts.Parent != nil {
+			if err := c.SetParent(opts.Parent); err != nil {
+				return nil, fmt.Errorf("could node set parent: %v", err)
+			}
+		}
+
+	}
+	return &c, nil
 }
 
-// SetSelector is part of TestingNode
-func (n CrushNode) SetSelector(Selector Selector) {
-	n.Selector = Selector
+// GetID returns node ID.
+func (c *CrushNode) GetID() string {
+	return c.id
 }
 
-// Select is part of TestingNode
-func (n CrushNode) Select(input int64, round int64) Node {
-	return n.GetSelector().Select(input, round)
+// SetID sets node ID. This is required field for each node.
+func (c *CrushNode) SetID(ID string) error {
+	if ID == "" {
+		return fmt.Errorf("ID cannot be empty")
+	}
+	c.id = ID
+	return nil
 }
 
-// IsFailed return true if node is marked as failed.
-func (n TestingNode) IsFailed() bool {
-	return n.Failed
+// GetGroup returns horizontal group of the node,
+// eg. DataCenter, Disk if default settings are used.
+func (c *CrushNode) GetGroup() uint8 {
+	return c.group
+}
+
+// SetGroup sets horizontal group of the node,
+// eg. DataCenter, Disk if default settings are used.
+func (c *CrushNode) SetGroup(opt uint8) error {
+	c.group = opt
+	return nil
+}
+
+// GetParent returns parent object of curent node.
+func (c *CrushNode) GetParent() CNode {
+	return c.parent
+}
+
+// SetParent sets parent node.
+func (c *CrushNode) SetParent(opt CNode) error {
+	if c.GetGroup() == 0 {
+		return fmt.Errorf("root node cannot have parent")
+	}
+	if opt.GetID() == c.GetID() {
+		return fmt.Errorf("cannot add myself as a parent")
+	}
+	c.parent = opt
+	return nil
+}
+
+// GetChildrens returns slice containing childrens of
+// selected node
+func (c *CrushNode) GetChildrens() []CNode {
+	return c.childrens
+}
+
+// AddChildren sets node groups.
+// This setting may change hashing so it is not adviced to be used
+// after first use of hashing.
+func (c *CrushNode) AddChildren(opt CNode) error {
+	if opt.GetID() == c.GetID() {
+		return fmt.Errorf("cannot add myself as child")
+	}
+	if c.parent != nil {
+		if opt.GetID() == c.parent.GetID() {
+			return fmt.Errorf("cannot add parent as a child")
+		}
+	}
+	for _, childs := range c.childrens {
+		if opt.GetID() == childs.GetID() {
+			return fmt.Errorf("this child node already exist")
+		}
+	}
+	c.childrens = append(c.childrens, opt)
+	return nil
+}
+
+// AddChildrens adds multiple childrens.
+func (c *CrushNode) AddChildrens(opt []CNode) error {
+	for _, child := range opt {
+		if err := c.AddChildren(child); err != nil {
+			return fmt.Errorf("could not add child: %v", err)
+		}
+	}
+	return nil
+}
+
+// GetSelector returns selector for given node
+func (c *CrushNode) GetSelector() Selector {
+	return c.selector
+}
+
+// SetSelector changes selector for given CrushNode
+func (c *CrushNode) SetSelector(s Selector) {
+	c.selector = s
+}
+
+// Select implements selector interface and
+// returns result from selected algorithm for
+// selected criteria.
+func (c *CrushNode) Select(input int64, round int64) CNode {
+	return c.GetSelector().Select(input, round)
+}
+
+// GetWeight returns weight of the node.
+func (c *CrushNode) GetWeight() int64 {
+	return c.weight
+}
+
+// SetWeight sets weight for a node.
+func (c *CrushNode) SetWeight(opt int64) error {
+	c.weight = opt
+	return nil
+}
+
+// IsFailed returns true if node is marked as failed.
+func (c *CrushNode) IsFailed() bool {
+	return c.failed
+}
+
+// SetFailed marks node as failed.
+func (c *CrushNode) SetFailed() error {
+	c.failed = true
+	return nil
+}
+
+// SetHealthy marks node as healthy - failed false.
+func (c *CrushNode) SetHealthy() error {
+	c.failed = false
+	return nil
 }
 
 // IsOverloaded returns true if node is marked as overloaded.
-func (n TestingNode) IsOverloaded() bool {
-	return n.Overloaded
+func (c *CrushNode) IsOverloaded() bool {
+	return c.overloaded
 }
 
-// IsLeaf is part of TestingNode
-func (n TestingNode) IsLeaf() bool {
-	return len(n.Children) == 0
+// SetOverloaded marks node as overloaded.
+func (c *CrushNode) SetOverloaded() error {
+	c.overloaded = true
+	return nil
 }
 
-// GetParent is part of TestingNode
-func (n TestingNode) GetParent() Node {
-	return n.Parent
+// UnsetOverloaded marks node as not overloaded.
+func (c *CrushNode) UnsetOverloaded() error {
+	c.overloaded = false
+	return nil
 }
 
-// GetID is part of TestingNode
-func (n TestingNode) GetID() string {
-	return n.ID
+// IsLeaf returns true if node is a leaf.
+// (doesn't have any children)
+func (c *CrushNode) IsLeaf() bool {
+	return len(c.childrens) == 0
 }
 
-// GetWeight is part of TestingNode
-func (n TestingNode) GetWeight() int64 {
-	return n.Weight
-}
-
-// GetType is part of TestingNode
-func (n TestingNode) GetType() int {
-	return n.Type
-}
-
-// GetChildren is part of TestingNode
-func (n TestingNode) GetChildren() []Node {
-	return n.Children
-}
-
-// TestCompare is part of TestingNode
-func TestCompare(n Node) bool {
-	tNode, ok := n.(TestingNode)
-	if ok {
-		return len(tNode.Children) > 0
+// IsRoot returns true if node is a Root.
+// (doesn't have any parents)
+func (c *CrushNode) IsRoot() bool {
+	if c.parent != nil {
+		return false
 	}
-	return false
+	return true
 }

--- a/selector.go
+++ b/selector.go
@@ -1,5 +1,0 @@
-package gocrush
-// Selector interface
-type Selector interface {
-	Select(input int64, round int64) Node
-}

--- a/strawselector.go
+++ b/strawselector.go
@@ -1,21 +1,20 @@
 package gocrush
 
 import (
-	//"log"
 	"math"
 )
 
 // StrawSelector implements Selector interface
 type StrawSelector struct {
-	Straws map[Node]int64
+	Straws map[CNode]int64
 }
 
 // NewStrawSelector returns new StrawSelector
-func NewStrawSelector(n Node) *StrawSelector {
+func NewStrawSelector(n CNode) *StrawSelector {
 	var s = new(StrawSelector)
-	s.Straws = make(map[Node]int64)
+	s.Straws = make(map[CNode]int64)
 	if !n.IsLeaf() {
-		var sortedNodes = n.GetChildren()
+		var sortedNodes = n.GetChildrens()
 		var numLeft = len(sortedNodes)
 		var straw float64 = 1.0
 		var wbelow float64 = 0.0
@@ -33,8 +32,6 @@ func NewStrawSelector(n Node) *StrawSelector {
 			if i == len(sortedNodes) {
 				break
 			}
-
-			current = sortedNodes[i]
 			var previous = sortedNodes[i-1]
 			if current.GetWeight() == previous.GetWeight() {
 				continue
@@ -57,8 +54,8 @@ func NewStrawSelector(n Node) *StrawSelector {
 }
 
 // Select returns selected node
-func (s *StrawSelector) Select(input int64, round int64) Node {
-	var result Node
+func (s *StrawSelector) Select(input int64, round int64) CNode {
+	var result CNode
 	var hiScore = int64(-1)
 	for child, straw := range s.Straws {
 		var score = weightedScore(child, straw, input, round)
@@ -73,8 +70,7 @@ func (s *StrawSelector) Select(input int64, round int64) Node {
 	return result
 }
 
-func weightedScore(child Node, straw int64, input int64, round int64) int64 {
-
+func weightedScore(child CNode, straw int64, input int64, round int64) int64 {
 	var hash = hash3(input, btoi(digestString(child.GetID())), round)
 	hash = hash & 0xFFFF
 	var weightedScore = hash * straw

--- a/treeselector.go
+++ b/treeselector.go
@@ -2,21 +2,21 @@ package gocrush
 
 // TreeSelector implements Select interface
 type TreeSelector struct {
-	Node        Node
+	Node        CNode
 	weights     []int64
 	totalWeight int64
 }
 
 // NewTreeSelector returns new TreeSelector
-func NewTreeSelector(n Node) *TreeSelector {
+func NewTreeSelector(n CNode) *TreeSelector {
 	var t = new(TreeSelector)
 	if !n.IsLeaf() {
 		t.Node = n
-		var depth = depth(len(n.GetChildren()))
+		var depth = depth(len(n.GetChildrens()))
 		t.weights = make([]int64, 1<<uint(depth))
 
-		//log.Printf("Tree with depth of %d for %d items and %d nodes", depth, len(n.Children), len(t.weights))
-		for idx, child := range n.GetChildren() {
+		//log.Printf("Tree with depth of %d for %d items and %d nodes", depth, len(n.childrens), len(t.weights))
+		for idx, child := range n.GetChildrens() {
 			if child == nil {
 				panic("Null child")
 			}
@@ -35,7 +35,7 @@ func NewTreeSelector(n Node) *TreeSelector {
 }
 
 /*func (t *TreeSelector) AddItem(n Node) {
-	var newSize int = len(t.Node.GetChildren()) + 1
+	var newSize int = len(t.Node.GetChildrens()) + 1
 	var depth = depth(newSize)
 	node := (((newSize - 1) + 1) << 1) - 1
 	var newSlice = make([]int64, 1<<uint(depth))
@@ -50,8 +50,8 @@ func NewTreeSelector(n Node) *TreeSelector {
 		node = parent(node)
 		t.weights[node] += n.GetWeight()
 	}
-	t.Node.Children = append(t.Node.Children, n)
-	t.totalWeight += n.Weight
+	t.Node.childrens = append(t.Node.childrens, n)
+	t.totalWeight += n.weight
 
 }*/
 
@@ -96,7 +96,7 @@ func right(x int) int {
 }
 
 // Select returns a node
-func (s *TreeSelector) Select(input int64, round int64) Node {
+func (s *TreeSelector) Select(input int64, round int64) CNode {
 	n := len(s.weights) >> 1
 	for (n & 1) < 1 {
 		var l int
@@ -110,7 +110,7 @@ func (s *TreeSelector) Select(input int64, round int64) Node {
 			n = right(n)
 		}
 	}
-	var result Node
-	result = s.Node.GetChildren()[n>>1]
+	var result CNode
+	result = s.Node.GetChildrens()[n>>1]
 	return result
 }

--- a/treeselector_test.go
+++ b/treeselector_test.go
@@ -1,22 +1,22 @@
 package gocrush
 
 import (
-	"github.com/stretchr/testify/assert"
-	//"log"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTreeSelector(t *testing.T) {
-	node := new(TestingNode)
-	node.Children = make([]Node, 8)
+	node := new(CrushNode)
+	node.childrens = make([]CNode, 8)
 	counter := make(map[string]int)
 	for i := 0; i < 8; i++ {
-		child := new(TestingNode)
-		child.Weight = 1
-		child.ID = "Child" + strconv.Itoa(i)
-		node.Children[i] = child
-		counter[child.ID] = 0
+		child := new(CrushNode)
+		child.weight = 1
+		child.id = "Child" + strconv.Itoa(i)
+		node.childrens[i] = child
+		counter[child.id] = 0
 	}
 	selector := NewTreeSelector(node)
 
@@ -39,14 +39,14 @@ func TestTreeSelector(t *testing.T) {
 }
 
 func TestTreeSelectorAdd(t *testing.T) {
-	node := new(TestingNode)
-	node.Children = make([]Node, 8)
-	counter := make(map[string]Node)
+	node := new(CrushNode)
+	node.childrens = make([]CNode, 8)
+	counter := make(map[string]CNode)
 	for i := 0; i < 8; i++ {
-		child := new(TestingNode)
-		child.Weight = 1
-		child.ID = "Child" + strconv.Itoa(i)
-		node.Children[i] = child
+		child := new(CrushNode)
+		child.weight = 1
+		child.id = "Child" + strconv.Itoa(i)
+		node.childrens[i] = child
 	}
 	selector := NewTreeSelector(node)
 	for i := int64(0); i < 5; i++ {
@@ -57,10 +57,10 @@ func TestTreeSelectorAdd(t *testing.T) {
 		}
 
 	}
-	child := new(TestingNode)
-	child.Weight = 1
-	child.ID = "Child9"
-	node.Children = append(node.Children, child)
+	child := new(CrushNode)
+	child.weight = 1
+	child.id = "Child9"
+	node.childrens = append(node.childrens, child)
 	selector = NewTreeSelector(node)
 	for i := int64(0); i < 5; i++ {
 		for r := int64(0); r < 3; r++ {

--- a/uniformselector.go
+++ b/uniformselector.go
@@ -1,32 +1,31 @@
 package gocrush
-// UniformSelector implements Select interface
-type UniformSelector struct {
-	Node        Node
-	totalWeight int64
 
-	perm  int64
-	perms []int64
+// UniformSelector implements Selector interface
+type UniformSelector struct {
+	Node        CNode
+	totalWeight int64
+	perm        int64
+	perms       []int64
 	// This is not thread safe, which makes me unhappy....
 	curInput int64
 }
 
 // NewUniformSelector returns new UniformSelector
-func NewUniformSelector(n Node) *UniformSelector {
+func NewUniformSelector(n CNode) *UniformSelector {
 	var u = new(UniformSelector)
 	if !n.IsLeaf() {
-		u.totalWeight = int64(len(n.GetChildren())) * n.GetWeight()
+		u.totalWeight = int64(len(n.GetChildrens())) * n.GetWeight()
 		u.Node = n
-		u.perms = make([]int64, len(n.GetChildren()))
+		u.perms = make([]int64, len(n.GetChildrens()))
 		u.perm = 0
 		u.curInput = -1
 	}
-
 	return u
 }
 
 // Select returns a node
-func (s *UniformSelector) Select(input int64, round int64) Node {
-	var size = len(s.Node.GetChildren())
+func (s *UniformSelector) Select(input int64, round int64) CNode {
+	var size = len(s.Node.GetChildrens())
 	var pr int64 = int64(round % int64(size))
 	if s.curInput != input || s.perm == 0 {
 		s.curInput = input
@@ -34,7 +33,7 @@ func (s *UniformSelector) Select(input int64, round int64) Node {
 			hash := hash3(input, btoi(digestString(s.Node.GetID())), 0) % int64(size)
 			s.perms[0] = hash
 			s.perm = 0xffff
-			return s.Node.GetChildren()[hash]
+			return s.Node.GetChildrens()[hash]
 		}
 		for i := 0; i < size; i++ {
 			s.perms[i] = int64(i)
@@ -59,5 +58,5 @@ func (s *UniformSelector) Select(input int64, round int64) Node {
 		}
 		s.perm++
 	}
-	return s.Node.GetChildren()[s.perms[pr]]
+	return s.Node.GetChildrens()[s.perms[pr]]
 }

--- a/uniformselector_test.go
+++ b/uniformselector_test.go
@@ -1,22 +1,22 @@
 package gocrush
 
 import (
-	"github.com/stretchr/testify/assert"
-	//"log"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUniformSelector(t *testing.T) {
-	node := new(TestingNode)
-	node.Children = make([]Node, 8)
+	node := new(CrushNode)
+	node.childrens = make([]CNode, 8)
 	counter := make(map[string]int)
 	for i := 0; i < 8; i++ {
-		child := new(TestingNode)
-		child.Weight = 1
-		child.ID = "Child" + strconv.Itoa(i)
-		node.Children[i] = child
-		counter[child.ID] = 0
+		child := new(CrushNode)
+		child.weight = 1
+		child.id = "Child" + strconv.Itoa(i)
+		node.childrens[i] = child
+		counter[child.id] = 0
 	}
 	selector := NewUniformSelector(node)
 
@@ -39,14 +39,14 @@ func TestUniformSelector(t *testing.T) {
 }
 
 func TestUniformSelectorAdd(t *testing.T) {
-	node := new(TestingNode)
-	node.Children = make([]Node, 8)
-	counter := make(map[string]Node)
+	node := new(CrushNode)
+	node.childrens = make([]CNode, 8)
+	counter := make(map[string]CNode)
 	for i := 0; i < 8; i++ {
-		child := new(TestingNode)
-		child.Weight = 1
-		child.ID = "Child" + strconv.Itoa(i)
-		node.Children[i] = child
+		child := new(CrushNode)
+		child.weight = 1
+		child.id = "Child" + strconv.Itoa(i)
+		node.childrens[i] = child
 	}
 	selector := NewUniformSelector(node)
 	for i := int64(0); i < 5; i++ {
@@ -58,10 +58,10 @@ func TestUniformSelectorAdd(t *testing.T) {
 
 	}
 
-	child := new(TestingNode)
-	child.Weight = 1
-	child.ID = "Child9"
-	node.Children = append(node.Children, child)
+	child := new(CrushNode)
+	child.weight = 1
+	child.id = "Child9"
+	node.childrens = append(node.childrens, child)
 	selector = NewUniformSelector(node)
 	for i := int64(0); i < 5; i++ {
 		for r := int64(0); r < 3; r++ {

--- a/unweightedhashselector.go
+++ b/unweightedhashselector.go
@@ -8,7 +8,7 @@ import (
 // UnweightedHashSelector implements Selector interface
 type UnweightedHashSelector struct {
 	tokenList utokenList
-	tokenMap  map[uint64]Node
+	tokenMap  map[uint64]CNode
 }
 type utokenList []uint64
 
@@ -31,11 +31,11 @@ func hashVal(bKey []byte) uint64 {
 }
 
 // NewUnweightedHashSelector returns new UnweightedHashSelector
-func NewUnweightedHashSelector(n Node) *UnweightedHashSelector {
+func NewUnweightedHashSelector(n CNode) *UnweightedHashSelector {
 	var s = new(UnweightedHashSelector)
 	if !n.IsLeaf() {
-		nodes := n.GetChildren()
-		s.tokenMap = make(map[uint64]Node)
+		nodes := n.GetChildrens()
+		s.tokenMap = make(map[uint64]CNode)
 		var factor int = 60 * len(nodes) * len(nodes)
 		idx := 0
 		s.tokenList = make([]uint64, len(nodes)*factor*3)
@@ -57,7 +57,7 @@ func NewUnweightedHashSelector(n Node) *UnweightedHashSelector {
 }
 
 // Select returns a node
-func (s *UnweightedHashSelector) Select(input int64, round int64) Node {
+func (s *UnweightedHashSelector) Select(input int64, round int64) CNode {
 	var hash = hash2(input, round)
 	token := uint64(hash)
 	return s.tokenMap[s.findToken(token)]

--- a/unweightedhashselector_bench_test.go
+++ b/unweightedhashselector_bench_test.go
@@ -1,7 +1,6 @@
 package gocrush
 
 import (
-	//"log"
 	"fmt"
 	"runtime"
 	"strconv"
@@ -13,15 +12,15 @@ func BenchmarkUnwweightedHashSelector(b *testing.B) {
 	memStats := new(runtime.MemStats)
 	runtime.GC()
 	runtime.ReadMemStats(memStats)
-	node := new(TestingNode)
-	node.Children = make([]Node, 10000)
+	node := new(CrushNode)
+	node.childrens = make([]CNode, 10000)
 	counter := make(map[string]int)
 	for i := 0; i < 10000; i++ {
-		child := new(TestingNode)
-		child.Weight = 1
-		child.ID = "Child" + strconv.Itoa(i)
-		node.Children[i] = child
-		counter[child.ID] = 0
+		child := new(CrushNode)
+		child.weight = 1
+		child.id = "Child" + strconv.Itoa(i)
+		node.childrens[i] = child
+		counter[child.id] = 0
 	}
 	b.StartTimer()
 	for x := 0; x < b.N; x++ {

--- a/unweightedhashselector_test.go.bck
+++ b/unweightedhashselector_test.go.bck
@@ -8,15 +8,15 @@ import (
 )
 
 func TestUnwweightedHashSelector(t *testing.T) {
-	node := new(TestingNode)
-	node.Children = make([]Node, 8)
+	node := new(CrushNode)
+	node.childrens = make([]Node, 8)
 	counter := make(map[string]int)
 	for i := 0; i < 8; i++ {
-		child := new(TestingNode)
-		child.Weight = 1
-		child.ID = "Child" + strconv.Itoa(i)
-		node.Children[i] = child
-		counter[child.ID] = 0
+		child := new(CrushNode)
+		child.weight = 1
+		child.id = "Child" + strconv.Itoa(i)
+		node.childrens[i] = child
+		counter[child.id] = 0
 	}
 	selector := NewUnweightedHashSelector(node)
 
@@ -39,14 +39,14 @@ func TestUnwweightedHashSelector(t *testing.T) {
 }
 
 /*func TestUnweightedHashSelectorAdd(t *testing.T) {
-	node := new(TestingNode)
-	node.Children = make([]Node, 8)
+	node := new(CrushNode)
+	node.childrens = make([]Node, 8)
 	counter := make(map[string]Node)
 	for i := 0; i < 8; i++ {
-		child := new(TestingNode)
-		child.Weight = 1
-		child.ID = "Child" + strconv.Itoa(i)
-		node.Children[i] = child
+		child := new(CrushNode)
+		child.weight = 1
+		child.id = "Child" + strconv.Itoa(i)
+		node.childrens[i] = child
 	}
 	selector := NewUnweightedHashSelector(node)
 	for i := int64(0); i < 5; i++ {
@@ -58,10 +58,10 @@ func TestUnwweightedHashSelector(t *testing.T) {
 
 	}
 	//log.Printf("Round 2")
-	child := new(TestingNode)
-	child.Weight = 1
-	child.ID = "Child9"
-	node.Children = append(node.Children, child)
+	child := new(CrushNode)
+	child.weight = 1
+	child.id = "Child9"
+	node.childrens = append(node.childrens, child)
 	selector = NewUnweightedHashSelector(node)
 	for i := int64(0); i < 5; i++ {
 		for r := int64(0); r < 3; r++ {


### PR DESCRIPTION
- switch to go.mod
- rewrite Node entity to guard it behind functions instead of direct struct manipulations
- rewrite Node entity and spawn it with New function
- rewrite Crush entity to utilize New
- rewrite Crush to use pre-defined consts and defaults
- initialize examples directory, which are different package than main package